### PR TITLE
fix typo in README keybindings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you used this package before its `1.0` version, you need to read the followin
 
 ## Keybindings
 
-With the success of Atom, it's really difficult to choose keybindings that will not enter in conflict whit anyone else's packages, so I have removed the default keystrokes and let the keymap empty to let you set your own keybindings.
+With the success of Atom, it's really difficult to choose keybindings that will not enter in conflict whit anyone else's packages, so I have removed the default keystrokes and left the keymap empty to let you set your own keybindings.
 
 See [keymaps/pane-manager.cson](https://github.com/leny/atom-pane-manager/blob/master/keymaps/pane-manager.cson) for suggestions.
 

--- a/keymaps/pane-manager.cson
+++ b/keymaps/pane-manager.cson
@@ -1,7 +1,7 @@
 # With the success of Atom, it's really difficult to choose keybindings that
-# will not enter in conflict whit anyone else's packages, so I let this file
+# will not enter in conflict with anyone else's packages, so I left this file
 # empty to set your own keybindings.
-# For you informations, here's an exemple of my keybindings for pane-manager
+# For your information, here's an exemple of my keybindings for pane-manager
 
 # '.platform-linux atom-workspace, .platform-win32 atom-workspace':
 #   # Layout management


### PR DESCRIPTION
thanks for putting this together @leny I've been trying to switch to atom from st and I miss [origami](https://github.com/SublimeText/Origami), but this package is another step towards atom 😄
