### PR TITLE
Fix application freezing when using plugin

### DIFF
--- a/lib/pane-utilities.js
+++ b/lib/pane-utilities.js
@@ -1,17 +1,18 @@
 "use babel";
 
 let oPaneUtilities,
+    fGetCenterPanes,
     fGetPaneAt;
+
+fGetCenterPanes = function() {
+    return atom.workspace.getCenter().getPanes();
+};
 
 fGetPaneAt = function( iPaneIndex ) {
     let aPanes = fGetCenterPanes();
 
     return aPanes[ iPaneIndex ] || aPanes[ aPanes.length - 1 ];
 };
-
-fGetCenterPanes = function() {
-    return atom.workspace.getCenter().getPanes();
-}
 
 oPaneUtilities = {
     clearPanes() {

--- a/lib/pane-utilities.js
+++ b/lib/pane-utilities.js
@@ -4,16 +4,20 @@ let oPaneUtilities,
     fGetPaneAt;
 
 fGetPaneAt = function( iPaneIndex ) {
-    let aPanes = atom.workspace.getPanes();
+    let aPanes = fGetCenterPanes();
 
     return aPanes[ iPaneIndex ] || aPanes[ aPanes.length - 1 ];
 };
+
+fGetCenterPanes = function() {
+    return atom.workspace.getCenter().getPanes();
+}
 
 oPaneUtilities = {
     clearPanes() {
         let aPanes;
 
-        while ( ( aPanes = atom.workspace.getPanes() ).length > 1 ) {
+        while ( ( aPanes = fGetCenterPanes() ).length > 1 ) {
             aPanes[ aPanes.length - 1 ].destroy();
         }
 
@@ -29,7 +33,7 @@ oPaneUtilities = {
     saveItems() {
         let oFirstPane = fGetPaneAt( 0 );
 
-        atom.workspace.getPanes().forEach( ( oPane, iPaneIndex ) => {
+        fGetCenterPanes().forEach( ( oPane, iPaneIndex ) => {
             for ( let oItem of oPane.getItems() ) {
                 oItem.originalPaneIndex = iPaneIndex;
                 if ( iPaneIndex > 0 ) {
@@ -84,7 +88,7 @@ oPaneUtilities = {
         return this;
     },
     applyLayout( aLayout ) {
-        let oPanes = atom.workspace.getPanes(),
+        let oPanes = fGetCenterPanes(),
             iHorizontalDivisions;
 
         // divide columns
@@ -94,7 +98,7 @@ oPaneUtilities = {
         }
 
         // divide rows
-        oPanes = atom.workspace.getPanes();
+        oPanes = fGetCenterPanes();
         aLayout.forEach( ( iRows, iIndex ) => {
             let iVerticalDivisions = iRows - 1;
 


### PR DESCRIPTION
Fix for issue #8 

### What does this PR do? ###
* Updates to limit the pane management to only the center workspace
* Adds new function to retrieve the center panes
* Updates existing functions to use the new function for pane retrieval

The fix was essentially to ignore any panes that were inside the new docks that were added to atom recently by grabbing on the center pane container from the workspace.

I would appreciate if others could help test this to make sure it covers all area of functionality. I have tested it with my setup which consists of shortcuts to split from 1 to 4 columns and I haven't seen any issues.